### PR TITLE
Fix popup theme

### DIFF
--- a/app/src/main/res/layout/main_activity.xml
+++ b/app/src/main/res/layout/main_activity.xml
@@ -14,7 +14,6 @@
         android:layout_height="wrap_content"
         app:elevation="4dp"
         android:orientation="vertical"
-        app:popupTheme="@style/Theme.Apps.PopUpOverlay"
         tools:menu="@menu/main_screen_menu" />
 
     <androidx.coordinatorlayout.widget.CoordinatorLayout

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -7,6 +7,4 @@
         <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:windowLightStatusBar">true</item>
     </style>
-
-    <style name="Theme.Apps.PopUpOverlay" parent="ThemeOverlay.Material3.Light" />
 </resources>


### PR DESCRIPTION
The xml style was overriding the dynamic theme that's applied in the Application class. This resulted in the popup appearing with the stock Material3 purple-tinted background on Android 12 or greater where it should follow the user-set color.

Before:
![image](https://github.com/user-attachments/assets/99602801-3de2-4d20-a460-04f3660b2893)

After:
![image](https://github.com/user-attachments/assets/f0fa0e03-1c5f-4b75-8f41-c74da762e9aa)
