### PR TITLE
Adapt swipe to refresh indicator to system theme

### DIFF
--- a/app/src/main/java/app/grapheneos/apps/ui/MainScreen.kt
+++ b/app/src/main/java/app/grapheneos/apps/ui/MainScreen.kt
@@ -21,6 +21,7 @@ import app.grapheneos.apps.databinding.MainScreenBinding
 import app.grapheneos.apps.util.intent
 import com.google.android.material.badge.BadgeDrawable
 import com.google.android.material.badge.BadgeUtils
+import com.google.android.material.color.MaterialColors
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -37,6 +38,21 @@ open class MainScreen : PackageListFragment<MainScreenBinding>(), MenuProvider {
 
     override fun onViewsCreated(views: MainScreenBinding, savedInstanceState: Bundle?) {
         createListAdapter(views.appList)
+
+        views.swipeRefreshContainer.apply {
+            setProgressBackgroundColorSchemeColor(
+                MaterialColors.getColor(
+                    this,
+                    com.google.android.material.R.attr.colorSurface
+                )
+            )
+            setColorSchemeColors(
+                MaterialColors.getColor(
+                    this,
+                    com.google.android.material.R.attr.colorPrimary
+                )
+            )
+        }
 
         views.swipeRefreshContainer.setOnRefreshListener {
             CoroutineScope(Dispatchers.Main).launch {


### PR DESCRIPTION
Now the indicator will change when swapping between light/dark mode instead of always using the light mode colors.

Dark mode before:
![image](https://github.com/user-attachments/assets/44652e21-cdb0-477e-ae1e-eda3c63191af)


Dark mode after:
![image](https://github.com/user-attachments/assets/b1bf55b6-d113-464d-ae9e-e0bcf3e8bc6d)
