### PR TITLE
Fix details screen padding

### DIFF
--- a/app/src/main/res/layout/details_screen.xml
+++ b/app/src/main/res/layout/details_screen.xml
@@ -5,7 +5,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/details_screen_inner_layout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:clipToPadding="false">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
Disables clipToPadding for the root ScrollView for the details screen to prevent clipping at the bottom of the list where the navigation bar appears.

Before:
![image](https://github.com/user-attachments/assets/d64b722e-dd84-4f59-8674-86f867d8faa0)

After:
![image](https://github.com/user-attachments/assets/8d70d253-b6c5-4de6-b723-83e967159943)
