### PR TITLE
fix regressed swipe refresh container colors by switching back to col…

### DIFF
--- a/app/src/main/java/app/grapheneos/apps/ui/MainScreen.kt
+++ b/app/src/main/java/app/grapheneos/apps/ui/MainScreen.kt
@@ -43,7 +43,7 @@ open class MainScreen : PackageListFragment<MainScreenBinding>(), MenuProvider {
             setProgressBackgroundColorSchemeColor(
                 MaterialColors.getColor(this, com.google.android.material.R.attr.colorSurface))
             setColorSchemeColors(
-                MaterialColors.getColor(this, com.google.android.material.R.attr.colorOnPrimaryContainer))
+                MaterialColors.getColor(this, androidx.appcompat.R.attr.colorPrimary))
         }
 
         views.swipeRefreshContainer.setOnRefreshListener {


### PR DESCRIPTION
…orPrimary

It was incorrectly switched to colorOnPrimaryContainer in https://github.com/GrapheneOS/AppStore/pull/434

The correct solution according to the changelog of the Material Components library (https://github.com/material-components/material-components-android/releases) is to switch to androidx.appcompat.R.attr.colorPrimary